### PR TITLE
fixes frame_type printing

### DIFF
--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -95,7 +95,8 @@ static int decode_packet(int *got_frame, int cached)
     }
 
    if (*got_frame) {
-        fprintf(stderr,"frame_type: %c; pkt_size: %d\n",
+       fflush(stderr);
+       fprintf(stderr,"<frame_type: %c; pkt_size: >%d\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
     }

--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -96,7 +96,7 @@ static int decode_packet(int *got_frame, int cached)
 
    if (*got_frame) {
        fflush(stderr);
-       fprintf(stderr,"<frame_type: %c; pkt_size: >%d\n",
+       fprintf(stderr,"<< frame_type: %c; pkt_size: %d >>\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
     }


### PR DESCRIPTION
Fixes the bug "frame_type:" message in the middle of a line. See #8 .

Futhermore, the printing uses `<` and `>` to enclose the message. So, even if the error appears in some platform, then the output can be reconstructed searching for `<frame_type: *>\n` and removing it.

I hope you want to merge it.
Regards.
