### PR TITLE
Restore the option to use a pre-existing log-data file

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -10,12 +10,6 @@ def main():
     parser.add_argument("output", help="Output file")
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite output")
     parser.add_argument(
-        "-d",
-        "--use-data-log-file",
-        action="store_true",
-        help="Use precalculated data-log file instead of the video",
-    )
-    parser.add_argument(
         "-of",
         "--output-format",
         default="ld-json",
@@ -27,6 +21,20 @@ def main():
         required=False,
         default="/usr/local/bin/",
         help="Path to ffmpeg-debug-qp (defaults to /usr/local/bin/)",
+    )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-d",
+        "--use-data-log-file",
+        action="store_true",
+        help="Use precalculated data-log file instead of the video",
+    )
+    group.add_argument(
+        "-n",
+        "--not-remove",
+        action="store_true",
+        help="Don't remove the temporal data-log file 'video.debug'",
     )
 
     group = parser.add_mutually_exclusive_group()
@@ -53,6 +61,7 @@ def main():
         force=args.force,
         output_format=args.output_format,
         logfile=args.use_data_log_file,
+        preserve=args.not_remove,
     ):
         print("Data extracted to: {0}".format(args["output"]))
 

--- a/extract.py
+++ b/extract.py
@@ -6,9 +6,15 @@ import parse_qp_output
 
 def main():
     parser = argparse.ArgumentParser(description="Parse QP values from ffmpeg-debug-qp")
-    parser.add_argument("video", type=str, help="Video file to generate output for")
+    parser.add_argument("video", metavar='video|datalog', type=str, help="Video file to generate output for")
     parser.add_argument("output", help="Output file")
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite output")
+    parser.add_argument(
+        "-d",
+        "--data-log-file",
+        action="store_true",
+        help="Use precalculated data-log file instead of the video",
+    )
     parser.add_argument(
         "-of",
         "--output-format",
@@ -46,6 +52,7 @@ def main():
         macroblock_data=args.include_macroblock_data,
         force=args.force,
         output_format=args.output_format,
+        logfile=args.data_log_file,
     ):
         print("Data extracted to: {0}".format(args["output"]))
 

--- a/extract.py
+++ b/extract.py
@@ -11,7 +11,7 @@ def main():
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite output")
     parser.add_argument(
         "-d",
-        "--data-log-file",
+        "--use-data-log-file",
         action="store_true",
         help="Use precalculated data-log file instead of the video",
     )
@@ -52,7 +52,7 @@ def main():
         macroblock_data=args.include_macroblock_data,
         force=args.force,
         output_format=args.output_format,
-        logfile=args.data_log_file,
+        logfile=args.use_data_log_file,
     ):
         print("Data extracted to: {0}".format(args["output"]))
 

--- a/parse_qp_output.py
+++ b/parse_qp_output.py
@@ -204,9 +204,9 @@ def format_line(data, data_format="ld-json"):
         raise RuntimeError("Wrong format, use ld-json or csv!")
 
 
-def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=False, force=False, output_format="ld-json"):
+def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=False, force=False, output_format="ld-json", logfile=False):
     if video != "-" and not os.path.isfile(video):
-        raise ValueError("No such video file: " + video)
+        raise ValueError("No such video|logfile file: " + video)
 
     if output_format not in OUTPUT_FORMATS:
         raise ValueError("Invalid output format! Must be one of: " + ", ".join(OUTPUT_FORMATS))
@@ -217,7 +217,10 @@ def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=
         if os.path.isfile(output) and not force:
             raise RuntimeError("Output " + output + " already exists; use force=True to overwrite")
 
-        debug_file = generate_log(video, force=force, macroblock_data=macroblock_data)
+        if not logfile:
+            debug_file = generate_log(video, force=force, macroblock_data=macroblock_data)
+        else:
+            debug_file = video
 
         if output_format == "json":
             # dump everything to the file
@@ -237,5 +240,5 @@ def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=
         sys.exit(1)
     finally:
         # Delete the debug file
-        if debug_file:
+        if debug_file and not logfile:
             os.remove(debug_file)

--- a/parse_qp_output.py
+++ b/parse_qp_output.py
@@ -204,7 +204,7 @@ def format_line(data, data_format="ld-json"):
         raise RuntimeError("Wrong format, use ld-json or csv!")
 
 
-def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=False, force=False, output_format="ld-json", logfile=False):
+def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=False, force=False, output_format="ld-json", logfile=False, preserve=False):
     if video != "-" and not os.path.isfile(video):
         raise ValueError("No such video|logfile file: " + video)
 
@@ -240,5 +240,5 @@ def extract_qp_data(video, output, compute_averages_only=False, macroblock_data=
         sys.exit(1)
     finally:
         # Delete the debug file
-        if debug_file and not logfile:
+        if debug_file and not logfile and not preserve:
             os.remove(debug_file)


### PR DESCRIPTION
When changed to the new `extract.py` tool the option to parse an existing log-data file is removed.
This patch restores this functionality, so you can reparse existing log files.
The new command is quite simple: `./extract.py -d video.logfile video.ldjson`

A future improvement (after the merge of this PR) can be to add a new parameter to not remove the log-data file, as this file consumes a lot of time to calculate it for large video sequences.
