### PR TITLE
Add support for PIPE input

### DIFF
--- a/parse_qp_output.py
+++ b/parse_qp_output.py
@@ -58,7 +58,7 @@ def generate_log(video_filename, force=False, macroblock_data=False):
     # TODO: Turn this into a tempfile?
     if video_filename == "-":
         # Using PIPE input
-        output_filename = "video.debug"
+        output_filename = "video." + uuid.uuid4().hex + ".debug"
         video_filename = "pipe:"
     else:
         output_filename = video_filename + ".debug"

--- a/parse_qp_output.py
+++ b/parse_qp_output.py
@@ -56,7 +56,12 @@ def generate_log(video_filename, force=False, macroblock_data=False):
         sys.exit(1)
 
     # TODO: Turn this into a tempfile?
-    output_filename = video_filename + ".debug"
+    if video_filename == "-":
+        # Using PIPE input
+        output_filename = "video.debug"
+        video_filename = "pipe:"
+    else:
+        output_filename = video_filename + ".debug"
     if not os.path.exists(output_filename) or force:
         args = [
             ff,


### PR DESCRIPTION
This patch resolves the issue #9 .

Now this works right: ` ffmpeg -i test.mp4 -f mpegts pipe:1 | ./extract.py -f -a - video.ldjson`

I hope it will be merged soon.
