### PR TITLE
Use the av_log_set_callback to fix threading log (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,4 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 FFmpeg libraries are licensed under the GNU Lesser General Public License, version 2.1.
+

--- a/README.md
+++ b/README.md
@@ -155,4 +155,3 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 FFmpeg libraries are licensed under the GNU Lesser General Public License, version 2.1.
-

--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -108,6 +108,12 @@ static int decode_packet(int *got_frame, int cached)
     return decoded;
 }
 
+void log_callback(void *ptr, int level, const char *fmt, va_list vargs)
+{
+    fflush(stderr);
+    vfprintf(stderr, fmt, vargs);
+}
+
 static int open_codec_context(int *stream_idx,
                               AVCodecContext **dec_ctx, AVFormatContext *fmt_ctx, enum AVMediaType type)
 {
@@ -192,6 +198,7 @@ int main (int argc, char **argv)
         }
     }
 
+    av_log_set_callback(log_callback);
     /* register all formats and codecs */
     av_register_all();
 

--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -94,11 +94,10 @@ static int decode_packet(int *got_frame, int cached)
     }
 
    if (*got_frame) {
-       fflush(stderr);
        fprintf(stderr,"<< frame_type: %c; pkt_size: %d >>\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
-        fflush(stderr);
+       fflush(stderr);
    }
 
     /* If we use the new API with reference counting, we own the data and need

--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -94,10 +94,9 @@ static int decode_packet(int *got_frame, int cached)
     }
 
    if (*got_frame) {
-       fprintf(stderr,"<< frame_type: %c; pkt_size: %d >>\n",
+       av_log(video_dec_ctx, AV_LOG_INFO, "<< frame_type: %c; pkt_size: %d >>\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
-       fflush(stderr);
    }
 
     /* If we use the new API with reference counting, we own the data and need

--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -98,7 +98,8 @@ static int decode_packet(int *got_frame, int cached)
        fprintf(stderr,"<< frame_type: %c; pkt_size: %d >>\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
-    }
+        fflush(stderr);
+   }
 
     /* If we use the new API with reference counting, we own the data and need
      * to de-reference it when we don't use it anymore */
@@ -110,8 +111,9 @@ static int decode_packet(int *got_frame, int cached)
 
 void log_callback(void *ptr, int level, const char *fmt, va_list vargs)
 {
+    // vfprintf(stderr, fmt, vargs);  // This without HEADER
+    av_log_default_callback(ptr, level, fmt, vargs);  // This with the HEADER
     fflush(stderr);
-    vfprintf(stderr, fmt, vargs);
 }
 
 static int open_codec_context(int *stream_idx,

--- a/parse_qp_output.py
+++ b/parse_qp_output.py
@@ -171,7 +171,7 @@ def parse_logfile(input_file, compute_averages_only, include_macroblock_data):
                     frame_qp_values.extend(line_qp_values)
                 continue
             if "pkt_size" in line:
-                frame_size = int(re.findall(r'\d+', line)[0])
+                frame_size = int(re.findall(r'\d+', line[line.rfind("pkt_size"):])[0])
 
         # yield last frame
         if has_current_frame_data:


### PR DESCRIPTION
This version really works in Windows. So it supersedes #24 .

Please merge it!