### PR TITLE
fix log flushing and parsing

### DIFF
--- a/ffmpeg_debug_qp.c
+++ b/ffmpeg_debug_qp.c
@@ -94,11 +94,10 @@ static int decode_packet(int *got_frame, int cached)
     }
 
    if (*got_frame) {
-       fflush(stderr);
-       fprintf(stderr,"<< frame_type: %c; pkt_size: %d >>\n",
+       av_log(video_dec_ctx, AV_LOG_INFO, "<< frame_type: %c; pkt_size: %d >>\n",
                 av_get_picture_type_char(frame->pict_type),
                 av_frame_get_pkt_size(frame));
-    }
+   }
 
     /* If we use the new API with reference counting, we own the data and need
      * to de-reference it when we don't use it anymore */
@@ -106,6 +105,13 @@ static int decode_packet(int *got_frame, int cached)
         av_frame_unref(frame);
 
     return decoded;
+}
+
+void log_callback(void *ptr, int level, const char *fmt, va_list vargs)
+{
+    // vfprintf(stderr, fmt, vargs);  // This without HEADER
+    av_log_default_callback(ptr, level, fmt, vargs);  // This with the HEADER
+    fflush(stderr);
 }
 
 static int open_codec_context(int *stream_idx,
@@ -192,6 +198,7 @@ int main (int argc, char **argv)
         }
     }
 
+    av_log_set_callback(log_callback);
     /* register all formats and codecs */
     av_register_all();
 

--- a/ffmpeg_debug_qp_parser/parse_qp_output.py
+++ b/ffmpeg_debug_qp_parser/parse_qp_output.py
@@ -218,7 +218,7 @@ def parse_logfile(input_file, compute_averages_only, include_macroblock_data):
                     frame_qp_values.extend(line_qp_values)
                 continue
             if "pkt_size" in line:
-                frame_size = int(re.findall(r"\d+", line)[0])
+                frame_size = int(re.findall(r'\d+', line[line.rfind("pkt_size"):])[0])
 
         # yield last frame
         if has_current_frame_data:


### PR DESCRIPTION
fix callback log – combination of different commits from https://github.com/slhck/ffmpeg-debug-qp/pull/26

Use the av_log_set_callback to fix threading log

This works on Linux and Windows

Fixes not writing the log HEADER

Remove duplicate flush because the rebase

Use native av_log function to fix the problem

Update README.md

Get number of size after the pkt_size label