### PR TITLE
Add tutorial on make compile the binary in MacOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For example on Ubuntu:
     sudo apt update && apt install libavdevice-dev libavformat-dev libavfilter-dev libavcodec-dev libswresample-dev libswscale-dev libavutil-dev build-essential pkg-config
     
 For exmaple on MacOS:
+
     brew install ffmpeg pkg-config
     
 And you might see the following out when `make` inside the `ffmpeg-debug-qp` folder if all goes well:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ For building:
 For example on Ubuntu:
 
     sudo apt update && apt install libavdevice-dev libavformat-dev libavfilter-dev libavcodec-dev libswresample-dev libswscale-dev libavutil-dev build-essential pkg-config
+    
+For exmaple on MacOS:
+    brew install ffmpeg pkg-config
+    
+And you might see the following out when `make` inside the `ffmpeg-debug-qp` folder if all goes well:
+
+```shell
+$ make
+cc   ffmpeg_debug_qp.o  -L/usr/local/Cellar/ffmpeg/4.3_2/lib -lavdevice -lavformat -lavfilter -lavcodec -lswresample -lswscale -lavutil  -o ffmpeg_debug_qp
+```
+
+And there should be a newly created file `ffmpeg_debug_qp` inside the folder.
 
 ## Windows platform
 


### PR DESCRIPTION
## Background

Currently there're only guideline for install ffmpeg-debug-qp in Ubuntu and Windows. For who was new and want to make the binary in MacOS, the specific tutorial would help.

## Change

Only add few lines in Readme

## Test Plan

Just update Readme, no need to test in this case
